### PR TITLE
Add San Diego Supercomputer Center to "who's using tus.io"

### DIFF
--- a/_data/logos.yml
+++ b/_data/logos.yml
@@ -12,3 +12,7 @@
 - url: 'http://hotpointapp.com'
   src: /assets/img/logos/hotpoint.png
   name: Hotpoint
+- url: 'http://www.sdsc.edu'
+  src: https://www.phylo.org/portal2/images/sdsc_main_logo.gif
+  name: San Diego Supercomputer Center
+  


### PR DESCRIPTION
Not sure if I got the format of the info right but I'm trying to add SDSC to the list, with a link to the sdsc logo and website.