### PR TITLE
Add "90 Seconds" to logos.yml

### DIFF
--- a/_data/logos.yml
+++ b/_data/logos.yml
@@ -16,3 +16,6 @@
 - url: http://www.sdsc.edu
   src: /assets/img/logos/san-diego-supercomputer-center.gif
   name: San Diego Supercomputer Center
+- url: https://90seconds.tv
+  src: https://90seconds.tv/wp-content/uploads/90-Seconds-logo-White-on-black.png
+  name: 90 Seconds - Cloud video production platform


### PR DESCRIPTION
We recently implemented tus.io using tus-js and tus-ruby-server to support video file uploads ranging from 50MB to 50GB. The protocol and implementations work perfectly.