### PR TITLE
Update description of tusdotnet

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -327,14 +327,14 @@ what protocol version you're targeting.
   </li>
 
   <li>
-    <a class="title" href="https://github.com/smatsson/tusdotnet">
-      smatsson/tusdotnet
+    <a class="title" href="https://github.com/tusdotnet/tusdotnet">
+      tusdotnet/tusdotnet
     </a>
 
     <div class="author">&mdash; by <a href="https://github.com/smatsson">Stefan Matsson</a></div>
 
     <div class="description">
-      <strong>.NET</strong> (C#, VB.NET etc) server implementation of tus <code>v1.0.0</code>.
+      <strong>.NET</strong> server implementation of tus <code>v1.0.0</code>, including all major extensions, that runs on both OWIN and ASP.NET Core.
     </div>
 
     <div class="license">Licensed under MIT</div>


### PR DESCRIPTION
Hi! 

tusdotnet is now feature complete! All major extensions are supported and a new release will hit Nuget in a couple of weeks.

I have updated the description of tusdotnet and also moved the entire repo to its own organization. I have some other stuff in the pipeline that will go into the same organization, e.g. a data store for tusdotnet that saves data to an Azure Storage account. 

What's your policy on using your logo? I was thinking about using it as the tusdotnet organization logo but with a added ".net" text in the lower right corner. 