### PR TITLE
Correct page titles

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
 
     {% assign used_title = page.title %}
     {% unless page.is_home %}
-      {% assign used_title = used_title | append: " | Transloadit" %}
+      {% assign used_title = used_title | append: " | tus" %}
     {% endunless %}
     {% unless layout.title_prefix %}
       {% assign used_title = used_title | prepend: layout.title_prefix %}

--- a/home.html
+++ b/home.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Resumable File Uploads
+title: tus - resumable file uploads
 container: "none"
 homepage: true
 is_home: true


### PR DESCRIPTION
There was Transloadit instead of tus in the page titles:

![artboard 2x](https://user-images.githubusercontent.com/375537/30060686-1044b78a-924d-11e7-8906-ca53a16d305b.png)

It has been fixed.

Also, there was no project name in the homepage title, which I believe is wrong. So I changed it from `Resumable File Uploads` to `tus - resumable file uploads`