### PR TITLE
Correct link to Shrine

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -463,8 +463,8 @@ what protocol version you're targeting.
     </a>
   </li>
   <li>
-    <a class="title" href="https://github.com/janko-m/shrine">
-      janko-m/shrine
+    <a class="title" href="https://github.com/shrinerb/shrine">
+      shrinerb/shrine
     </a>
   </li>
 </ul>


### PR DESCRIPTION
The Shrine repository has been moved to the "shrinerb" organization.