### PR TITLE
Update the font stack

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,9 +22,6 @@
 
     <!-- Twitter follow button script -->
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-
-    <script src="//use.typekit.net/zgo3uyj.js"></script>
-    <script>try{Typekit.load();}catch(e){}</script>
   </head>
 
   <body>

--- a/assets/stylesheets/blog.css.less
+++ b/assets/stylesheets/blog.css.less
@@ -18,7 +18,6 @@
 		}
 
 		.post-content {
-			font-family: "ff-tisa-web-pro";
 			color: #555;
 		}
 

--- a/assets/stylesheets/home.css.less
+++ b/assets/stylesheets/home.css.less
@@ -1,7 +1,6 @@
 .intro {
 	background: #fff;
 	color: @intro-color;
-	font-weight: 300;
 	position: relative;
 	text-align: center;
 

--- a/assets/stylesheets/layout.css.less
+++ b/assets/stylesheets/layout.css.less
@@ -5,7 +5,7 @@
 }
 
 body {
-	font-family: "proxima-nova", "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 a {

--- a/assets/stylesheets/layout.css.less
+++ b/assets/stylesheets/layout.css.less
@@ -6,6 +6,8 @@
 
 body {
 	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	-moz-osx-font-smoothing: grayscale;
+	-webkit-font-smoothing: antialiased;
 }
 
 a {


### PR DESCRIPTION
This PR fixes some problems with fonts. 

Firstly, we couldn't load a font from Typekit and had no fallbacks, so default font was shown:

![image](https://user-images.githubusercontent.com/375537/56211127-eb753f00-605f-11e9-8b23-ef7c3b35747e.png)

Also, we have a very thin font style used in the intro section. I replaced it with a more readable one.

![Screen Recording 2019-04-16 at 15 59](https://user-images.githubusercontent.com/375537/56211484-ad2c4f80-6060-11e9-92d5-761d4847bc47.gif)

