### PR TITLE
Make the paused state clearer

### DIFF
--- a/assets/javascripts/upload-demo.js
+++ b/assets/javascripts/upload-demo.js
@@ -113,11 +113,13 @@ function drawUploadControls (upload) {
       isUploadRunning = false
       pauseButton.textContent = 'Resume'
       textHeading.textContent = 'The upload is paused:'
+      progress.classList.add('paused')
     } else {
       upload.start()
       isUploadRunning = true
       pauseButton.textContent = 'Pause'
       textHeading.textContent = 'The upload is running:'
+      progress.classList.remove('paused')
     }
   })
 

--- a/assets/stylesheets/demo.css.less
+++ b/assets/stylesheets/demo.css.less
@@ -23,6 +23,7 @@
 
 	button {
 		padding: 0 16px;
+		min-width: 90px;
 	}
 }
 
@@ -58,9 +59,14 @@
 	}
 
 	.progress-bar {
-		transition: width 0.25s ease;
+		transition: width 0.25s ease, background-color 0.25s ease;
 		width: 0;
 		animation: progress-bar-stripes 2s linear infinite;
+	}
+
+	&.paused .progress-bar {
+		background-color: #4faa94;
+		animation-play-state: paused;
 	}
 }
 


### PR DESCRIPTION
Kevin's feedback:

> If i pause the upload, the progress bar still animates. it's not wrong maybe, but i would have expected that froze too then.

Here, it's fixed: the animation freezes on pause, and the green color also dims a little bit. I also set a min-width for progress bar's pause/resume button, so it won't be "jumping" because of the caption changes.

Preview:

![Screen Recording 2020-05-29 at 16 38](https://user-images.githubusercontent.com/375537/83265980-eb37f480-a1ca-11ea-9a81-b7898d73ce92.gif)
