### PR TITLE
Improve the protocol version select, and all selects in general

### DIFF
--- a/_layouts/protocol.html
+++ b/_layouts/protocol.html
@@ -5,14 +5,17 @@ layout: default
 <div class="protocol">
   <h1>
     Protocol
+  </h1>
 
-    {% assign versions = site.versions | reverse %}
+  {% assign versions = site.versions | reverse %}
+  <div class="protocol-version">
+    Version
     <select id="js-version-select">
       {% for version in versions %}
         <option value="{{ version.url }}" {% if page.url == version.url %}selected{% endif %}>{{ version.slug }}</option>
       {% endfor %}
     </select>
-  </h1>
+  </div>
 
   <p class="lead">
     This document contains the specification for the tus protocol which lays out exactly how tus clients and servers must behave. If you want a less formal and more intuitive introduction, we recommend you to also have a look at our <a href="/faq.html">FAQ</a>.

--- a/assets/stylesheets/layout.scss
+++ b/assets/stylesheets/layout.scss
@@ -43,10 +43,16 @@ textarea:focus {
   border-color: $scheme-secondary;
 }
 
-select,
-select:focus {
-  all: revert;
-  font-size: 16px;
+select {
+  padding: 3px 4px;
+}
+
+@-moz-document url-prefix() {
+  select,
+  select:focus {
+    all: revert;
+    font-size: 14px;
+  }
 }
 
 .button {

--- a/assets/stylesheets/layout.scss
+++ b/assets/stylesheets/layout.scss
@@ -43,6 +43,12 @@ textarea:focus {
   border-color: $scheme-secondary;
 }
 
+select,
+select:focus {
+  all: revert;
+  font-size: 16px;
+}
+
 .button {
   &.button-primary {
     background-color: $scheme-secondary;

--- a/assets/stylesheets/protocol.scss
+++ b/assets/stylesheets/protocol.scss
@@ -34,20 +34,21 @@
 }
 
 .protocol-version {
-  font-size: 16px;
   margin: 15px 0 20px;
   color: #555;
+  font-size: 14px;
 
   select {
     margin-left: 0.33em;
-    min-width: 80px;
+    min-width: 80px;    
+    height: auto;
   }
+
   
   @media screen and (min-width: 768px) {
     position: absolute;
-    top: 15px;
+    top: 12px;
     right: 15px;
     margin: 0;
-    font-size: 14px;
   }
 }

--- a/assets/stylesheets/protocol.scss
+++ b/assets/stylesheets/protocol.scss
@@ -40,11 +40,10 @@
 
   select {
     margin-left: 0.33em;
-    min-width: 80px;    
+    min-width: 80px;
     height: auto;
   }
 
-  
   @media screen and (min-width: 768px) {
     position: absolute;
     top: 12px;

--- a/assets/stylesheets/protocol.scss
+++ b/assets/stylesheets/protocol.scss
@@ -33,9 +33,21 @@
   }
 }
 
-#js-version-select {
-  font-size: 1.8rem;
-  font-weight: normal;
-  float: right;
-  margin-bottom: 0;
+.protocol-version {
+  font-size: 16px;
+  margin: 15px 0 20px;
+  color: #555;
+
+  select {
+    margin-left: 0.33em;
+    min-width: 80px;
+  }
+  
+  @media screen and (min-width: 768px) {
+    position: absolute;
+    top: 15px;
+    right: 15px;
+    margin: 0;
+    font-size: 14px;
+  }
 }


### PR DESCRIPTION
As Kevin mentioned in #174, there is an ugly select in the Protocol page. This is especially relevant to Firefox, where customized selects look really bad.

So, I've reset styles for all `<select>’s` in Firefox, and also slightly polished that particular protocol version select.

Before and after:

 
<img width="824" alt="Screenshot 2020-10-21 at 14 39 24" src="https://user-images.githubusercontent.com/375537/96716845-45219c80-13ae-11eb-9648-55d08fafd811.png">

<img width="825" alt="Screenshot 2020-10-21 at 14 59 53" src="https://user-images.githubusercontent.com/375537/96716854-481c8d00-13ae-11eb-91f6-1629792931b0.png">


