### PR TITLE
Use a meta tag instead of a file for Google Site Verification

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="google-site-verification" content="Y0C1UF4FAEedNCMjLTIm48uKmKyrqhZta6vAU7kQ_kw" />
 
     {% if page.noindex %}
       <meta name="robots" content="noindex">

--- a/google18275eed01f76b59.html
+++ b/google18275eed01f76b59.html
@@ -1,1 +1,0 @@
-google-site-verification: google18275eed01f76b59.html


### PR DESCRIPTION
We're pretty frequently receiving an email regarding mobile usability issues. Not only it's a bit annoying, but I'm afraid it might affect SEO:

<img width="670" alt="image" src="https://user-images.githubusercontent.com/375537/109627567-6b203000-7b4a-11eb-8314-f44160882cf9.png">

Some time ago I noticed that those errors are related to Google's verification HTML file which is very simple and, of course, is not optimized for mobile. Here, I'm trying to use another verification method (meta tag) which allows me to remove the HTML file. Hopefully, it's gonna fix the issue.

**Note:** I'll need to trigger a verification process manually on Google Console after this is merged & deployed.