### PR TITLE
logo: add RANCH Computing

### DIFF
--- a/_data/logos.yml
+++ b/_data/logos.yml
@@ -40,3 +40,6 @@
 - url: 'https://globalctoforum.org/'
   src:  /assets/img/logos/global-cto-forum.png
   name: Global CTO Forum
+- url: 'https://www.ranchcomputing.com'
+  src: 'https://www.ranchcomputing.com/assets/imgs/logo/ranch_blue.png'
+  name: RANCH Computing


### PR DESCRIPTION
Hi,

RANCH Computing has been using tus for some time now, this PR adds its logo.

However it will likely have no effect, since the current template only shows the first 5 logos (they are now 13):

https://github.com/tus/tus.io/blob/026a7fddf3bd6bed7fd067a76e660299f11ea42f/_content/home.html#L136

Should the template be updated to display more logos? (if no then the sentence `Do you also (plan to) use tus? Add your company` should be removed ^^)

---

PS: I also used tus for a personal file transfer and I documented my journey in a short blog post. Maybe you'll find it interesting:
https://log.pfad.fr/2021/receiving-large-file/