### PR TITLE
Run `yarn build` in CI check for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,6 @@ jobs:
       # make sure types are generated before linting
       - run: yarn astro sync
       - run: yarn lint
+      - run: yarn build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/components/RequestViewer.tsx
+++ b/src/components/RequestViewer.tsx
@@ -44,7 +44,10 @@ function updateTraffic(xhr: XMLHttpRequest) {
   traffic.value = updated
 }
 
-if (window?.XMLHttpRequest) {
+// `window` is not available when building the static version, so window?.XMLHttpRequest
+// would error out because window is not defined.
+// eslint-disable-next-line @typescript-eslint/prefer-optional-chain
+if (typeof window !== 'undefined' && window.XMLHttpRequest) {
   const xhrOpen = XMLHttpRequest.prototype.open
   const xhrSetRequestHeader = XMLHttpRequest.prototype.setRequestHeader
   const xhrSend = XMLHttpRequest.prototype.send


### PR DESCRIPTION
Otherwise build errors will not be visible in PRs. For example: https://github.com/tus/tus.io/actions/runs/5905861631/job/16020751357#step:7:175