### PR TITLE
Remove `cache: yarn`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x
-          cache: yarn
       - run: corepack enable
       - run: corepack prepare
       - run: yarn install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: yarn
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: corepack enable


### PR DESCRIPTION
To fix the errors about yarn in recent CI runs. See https://transloadit.slack.com/archives/C034DSPA1/p1701684846910509 and https://github.com/tus/tus.io/actions/runs/7085115412/job/19280734208