### PR TITLE
Fix rate limiting in CI build

### DIFF
--- a/src/lib/octokit.ts
+++ b/src/lib/octokit.ts
@@ -41,11 +41,16 @@ export const octokit = new TusOctokit({
         return true
       }
     },
-    onSecondaryRateLimit: (retryAfter, options, octokit) => {
-      // does not retry, only logs a warning
+    onSecondaryRateLimit: (retryAfter, options, octokit, retryCount) => {
       octokit.log.warn(
         `SecondaryRateLimit detected for request ${options.method} ${options.url}`,
       )
+
+      if (retryCount < 1) {
+        // only retries once
+        octokit.log.info(`Retrying after ${retryAfter} seconds!`)
+        return true
+      }
     },
   },
 })


### PR DESCRIPTION
CI is failing due to rate limits:

```
SecondaryRateLimit detected for request GET https://api.github.com/repositories/8825137/issues/comments?per_page=100&sort=created&direction=desc&page=30
 error   You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 4000:3A7D64:2C3F768:537C37A:66A81D2A.
  File:
    src/pages/support.mdx
  Stacktrace:
HttpError: You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 4000:3A7D64:2C3F768:537C37A:66A81D2A.
    at /home/runner/work/tus.io/tus.io/node_modules/@octokit/request/dist-node/index.js:112:21
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Job.doExecute (/home/runner/work/tus.io/tus.io/node_modules/bottleneck/light.js:405:18)
```

This PR is an attempt to fix this by retrying after a certain delay.