### PR TITLE
Fix warning about lower case HTTP method

### DIFF
--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -3,7 +3,7 @@ import rss from '@astrojs/rss'
 import { getCollection, getEntry } from 'astro:content'
 import type { APIRoute } from 'astro'
 
-export const get: APIRoute = async () => {
+export const GET: APIRoute = async () => {
   const blog = await getCollection('blog')
   return rss({
     title: 'tus.io',


### PR DESCRIPTION
Fixes this warning from the CI build:

```
 λ src/pages/rss.xml.ts
06:36:13 AM [astro] Lower case endpoint names are deprecated and will not be supported in Astro 4.0. Rename the endpoint get to GET.
  └─ /rss.xml (+14ms)
```