### PR TITLE
Create funding.json

### DIFF
--- a/public/funding.json
+++ b/public/funding.json
@@ -216,7 +216,8 @@
       {
         "guid": "opencollective",
         "type": "other",
-        "description": "We are in the process of setting up an Open Collective. Please e-mail me for details."
+        "address": "https://opencollective.com/tus",
+        "description": "We accept donations through Open Collective."
       }
     ],
     "plans": [

--- a/public/funding.json
+++ b/public/funding.json
@@ -22,9 +22,7 @@
         "url": "https://github.com/tus/tus-protocol",
         "wellKnown": "https://github.com/tus/tus-protocol/blob/main/.well-known/funding-manifest-urls"
       },
-      "licenses": [
-        "mit"
-      ],
+      "licenses": ["mit"],
       "tags": [
         "http",
         "upload",
@@ -36,7 +34,7 @@
     },
     {
       "guid": "tusd",
-      "name": "tusd", 
+      "name": "tusd",
       "description": "Tusd is a feature-rich server for resumable uploads written in Go.",
       "webpageUrl": {
         "url": "https://tus.github.io/tusd",
@@ -46,17 +44,8 @@
         "url": "https://github.com/tus/tusd",
         "wellKnown": "https://github.com/tus/tusd/blob/gh-pages/.well-known/funding-manifest-urls"
       },
-      "licenses": [
-        "mit"
-      ],
-      "tags": [
-        "http",
-        "upload", 
-        "file",
-        "resumable",
-        "go",
-        "server"
-      ]
+      "licenses": ["mit"],
+      "tags": ["http", "upload", "file", "resumable", "go", "server"]
     },
     {
       "guid": "tus-node-server",
@@ -67,20 +56,11 @@
         "wellKnown": "https://github.com/tus/tus-node-server/blob/main/.well-known/funding-manifest-urls"
       },
       "repositoryUrl": {
-        "url": "https://github.com/tus/tus-node-server", 
+        "url": "https://github.com/tus/tus-node-server",
         "wellKnown": "https://github.com/tus/tus-node-server/blob/main/.well-known/funding-manifest-urls"
       },
-      "licenses": [
-        "mit"
-      ],
-      "tags": [
-        "http",
-        "upload",
-        "file", 
-        "resumable",
-        "nodejs",
-        "server"
-      ]
+      "licenses": ["mit"],
+      "tags": ["http", "upload", "file", "resumable", "nodejs", "server"]
     },
     {
       "guid": "tus-js-client",
@@ -94,14 +74,12 @@
         "url": "https://github.com/tus/tus-js-client",
         "wellKnown": "https://github.com/tus/tus-js-client/blob/main/.well-known/funding-manifest-urls"
       },
-      "licenses": [
-        "mit"  
-      ],
+      "licenses": ["mit"],
       "tags": [
         "http",
         "upload",
         "file",
-        "resumable", 
+        "resumable",
         "javascript",
         "nodejs",
         "browser",
@@ -109,7 +87,7 @@
       ]
     },
     {
-      "guid": "tus-py-client", 
+      "guid": "tus-py-client",
       "name": "tus-py-client",
       "description": "Client implementation of the tus resumable upload protocol for Python.",
       "webpageUrl": {
@@ -120,21 +98,12 @@
         "url": "https://github.com/tus/tus-py-client",
         "wellKnown": "https://github.com/tus/tus-py-client/blob/main/.well-known/funding-manifest-urls"
       },
-      "licenses": [
-        "mit"
-      ],
-      "tags": [
-        "http",
-        "upload",
-        "file",
-        "resumable",
-        "python",
-        "client"
-      ]
+      "licenses": ["mit"],
+      "tags": ["http", "upload", "file", "resumable", "python", "client"]
     },
     {
       "guid": "tus-java-client",
-      "name": "tus-java-client", 
+      "name": "tus-java-client",
       "description": "Client implementation of the tus resumable upload protocol for Java.",
       "webpageUrl": {
         "url": "https://github.com/tus/tus-java-client",
@@ -144,17 +113,8 @@
         "url": "https://github.com/tus/tus-java-client",
         "wellKnown": "https://github.com/tus/tus-java-client/blob/main/.well-known/funding-manifest-urls"
       },
-      "licenses": [
-        "mit"
-      ],
-      "tags": [
-        "http",
-        "upload",
-        "file",
-        "resumable",
-        "java",
-        "client"
-      ]
+      "licenses": ["mit"],
+      "tags": ["http", "upload", "file", "resumable", "java", "client"]
     },
     {
       "guid": "tus-android-client",
@@ -168,17 +128,8 @@
         "url": "https://github.com/tus/tus-android-client",
         "wellKnown": "https://github.com/tus/tus-android-client/blob/main/.well-known/funding-manifest-urls"
       },
-      "licenses": [
-        "mit"
-      ],
-      "tags": [
-        "http", 
-        "upload",
-        "file",
-        "resumable",
-        "android",
-        "client"
-      ]
+      "licenses": ["mit"],
+      "tags": ["http", "upload", "file", "resumable", "android", "client"]
     },
     {
       "guid": "tuskit",
@@ -192,18 +143,8 @@
         "url": "https://github.com/tus/TUSKit",
         "wellKnown": "https://github.com/tus/TUSKit/blob/main/.well-known/funding-manifest-urls"
       },
-      "licenses": [
-        "mit"
-      ],
-      "tags": [
-        "http",
-        "upload", 
-        "file",
-        "resumable",
-        "ios",
-        "macos",
-        "client"
-      ]
+      "licenses": ["mit"],
+      "tags": ["http", "upload", "file", "resumable", "ios", "macos", "client"]
     }
   ],
   "funding": {

--- a/public/funding.json
+++ b/public/funding.json
@@ -19,8 +19,8 @@
         "url": "https://tus.io/protocols/resumable-upload"
       },
       "repositoryUrl": {
-        "url": "https://github.com/tus/tus-protocol",
-        "wellKnown": "https://github.com/tus/tus-protocol/blob/main/.well-known/funding-manifest-urls"
+        "url": "https://github.com/tus/tus-resumable-upload-protocol",
+        "wellKnown": "https://github.com/tus/tus-resumable-upload-protocol/blob/main/.well-known/funding-manifest-urls"
       },
       "licenses": ["mit"],
       "tags": [
@@ -42,7 +42,7 @@
       },
       "repositoryUrl": {
         "url": "https://github.com/tus/tusd",
-        "wellKnown": "https://github.com/tus/tusd/blob/gh-pages/.well-known/funding-manifest-urls"
+        "wellKnown": "https://github.com/tus/tusd/blob/main/.well-known/funding-manifest-urls"
       },
       "licenses": ["mit"],
       "tags": ["http", "upload", "file", "resumable", "go", "server"]

--- a/public/funding.json
+++ b/public/funding.json
@@ -222,15 +222,40 @@
     ],
     "plans": [
       {
+        "guid": "backer",
+        "status": "active",
+        "name": "Backer",
+        "amount": 2,
+        "currency": "EUR",
+        "frequency": "monthly",
+        "channels": ["opencollective"]
+      },
+      {
         "guid": "bronze",
         "status": "active",
         "name": "Bronze sponsor",
-        "amount": 100,
-        "currency": "USD",
+        "amount": 25,
+        "currency": "EUR",
         "frequency": "monthly",
-        "channels": [
-          "opencollective"
-        ]
+        "channels": ["opencollective"]
+      },
+      {
+        "guid": "silver",
+        "status": "active",
+        "name": "Silver sponsor",
+        "amount": 100,
+        "currency": "EUR",
+        "frequency": "monthly",
+        "channels": ["opencollective"]
+      },
+      {
+        "guid": "gold",
+        "status": "active",
+        "name": "Gold sponsor",
+        "amount": 500,
+        "currency": "EUR",
+        "frequency": "monthly",
+        "channels": ["opencollective"]
       }
     ],
     "history": []

--- a/public/funding.json
+++ b/public/funding.json
@@ -1,0 +1,237 @@
+{
+  "version": "v1.0.0",
+  "entity": {
+    "type": "group",
+    "role": "steward",
+    "name": "tus",
+    "email": "marius@tus.o",
+    "description": "Tus is an open protocol for resumable uploads over HTTP enabling file uploads to recover from network interruptions. We maintain open-source implementations to easily add resumability to every application.",
+    "webpageUrl": {
+      "url": "https://tus.io"
+    }
+  },
+  "projects": [
+    {
+      "guid": "tus",
+      "name": "tus",
+      "description": "Tus is an open protocol for resumable file uploads over HTTP. It enables reliable uploads that can resume after network interruptions.",
+      "webpageUrl": {
+        "url": "https://tus.io/protocols/resumable-upload"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/tus/tus-protocol",
+        "wellKnown": "https://github.com/tus/tus-protocol/blob/main/.well-known/funding-manifest-urls"
+      },
+      "licenses": [
+        "mit"
+      ],
+      "tags": [
+        "http",
+        "upload",
+        "file",
+        "resumable",
+        "protocol",
+        "specification"
+      ]
+    },
+    {
+      "guid": "tusd",
+      "name": "tusd", 
+      "description": "Tusd is a feature-rich server for resumable uploads written in Go.",
+      "webpageUrl": {
+        "url": "https://tus.github.io/tusd",
+        "wellKnown": "https://tus.github.io/tusd/.well-known/funding-manifest-urls"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/tus/tusd",
+        "wellKnown": "https://github.com/tus/tusd/blob/gh-pages/.well-known/funding-manifest-urls"
+      },
+      "licenses": [
+        "mit"
+      ],
+      "tags": [
+        "http",
+        "upload", 
+        "file",
+        "resumable",
+        "go",
+        "server"
+      ]
+    },
+    {
+      "guid": "tus-node-server",
+      "name": "tus-node-server",
+      "description": "Tus-node-server is a feature-rich server for resumable uploads written in Node.js.",
+      "webpageUrl": {
+        "url": "https://github.com/tus/tus-node-server",
+        "wellKnown": "https://github.com/tus/tus-node-server/blob/main/.well-known/funding-manifest-urls"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/tus/tus-node-server", 
+        "wellKnown": "https://github.com/tus/tus-node-server/blob/main/.well-known/funding-manifest-urls"
+      },
+      "licenses": [
+        "mit"
+      ],
+      "tags": [
+        "http",
+        "upload",
+        "file", 
+        "resumable",
+        "nodejs",
+        "server"
+      ]
+    },
+    {
+      "guid": "tus-js-client",
+      "name": "tus-js-client",
+      "description": "Client implementation of the tus resumable upload protocol for JavaScript (Node.js and browsers).",
+      "webpageUrl": {
+        "url": "https://github.com/tus/tus-js-client",
+        "wellKnown": "https://github.com/tus/tus-js-client/blob/main/.well-known/funding-manifest-urls"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/tus/tus-js-client",
+        "wellKnown": "https://github.com/tus/tus-js-client/blob/main/.well-known/funding-manifest-urls"
+      },
+      "licenses": [
+        "mit"  
+      ],
+      "tags": [
+        "http",
+        "upload",
+        "file",
+        "resumable", 
+        "javascript",
+        "nodejs",
+        "browser",
+        "client"
+      ]
+    },
+    {
+      "guid": "tus-py-client", 
+      "name": "tus-py-client",
+      "description": "Client implementation of the tus resumable upload protocol for Python.",
+      "webpageUrl": {
+        "url": "https://github.com/tus/tus-py-client",
+        "wellKnown": "https://github.com/tus/tus-py-client/blob/main/.well-known/funding-manifest-urls"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/tus/tus-py-client",
+        "wellKnown": "https://github.com/tus/tus-py-client/blob/main/.well-known/funding-manifest-urls"
+      },
+      "licenses": [
+        "mit"
+      ],
+      "tags": [
+        "http",
+        "upload",
+        "file",
+        "resumable",
+        "python",
+        "client"
+      ]
+    },
+    {
+      "guid": "tus-java-client",
+      "name": "tus-java-client", 
+      "description": "Client implementation of the tus resumable upload protocol for Java.",
+      "webpageUrl": {
+        "url": "https://github.com/tus/tus-java-client",
+        "wellKnown": "https://github.com/tus/tus-java-client/blob/main/.well-known/funding-manifest-urls"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/tus/tus-java-client",
+        "wellKnown": "https://github.com/tus/tus-java-client/blob/main/.well-known/funding-manifest-urls"
+      },
+      "licenses": [
+        "mit"
+      ],
+      "tags": [
+        "http",
+        "upload",
+        "file",
+        "resumable",
+        "java",
+        "client"
+      ]
+    },
+    {
+      "guid": "tus-android-client",
+      "name": "tus-android-client",
+      "description": "Client implementation of the tus resumable upload protocol for Android.",
+      "webpageUrl": {
+        "url": "https://github.com/tus/tus-android-client",
+        "wellKnown": "https://github.com/tus/tus-android-client/blob/main/.well-known/funding-manifest-urls"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/tus/tus-android-client",
+        "wellKnown": "https://github.com/tus/tus-android-client/blob/main/.well-known/funding-manifest-urls"
+      },
+      "licenses": [
+        "mit"
+      ],
+      "tags": [
+        "http", 
+        "upload",
+        "file",
+        "resumable",
+        "android",
+        "client"
+      ]
+    },
+    {
+      "guid": "tuskit",
+      "name": "TUSKit",
+      "description": "Client implementation of the tus resumable upload protocol for iOS and macOS.",
+      "webpageUrl": {
+        "url": "https://github.com/tus/TUSKit",
+        "wellKnown": "https://github.com/tus/TUSKit/blob/main/.well-known/funding-manifest-urls"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/tus/TUSKit",
+        "wellKnown": "https://github.com/tus/TUSKit/blob/main/.well-known/funding-manifest-urls"
+      },
+      "licenses": [
+        "mit"
+      ],
+      "tags": [
+        "http",
+        "upload", 
+        "file",
+        "resumable",
+        "ios",
+        "macos",
+        "client"
+      ]
+    }
+  ],
+  "funding": {
+    "channels": [
+      {
+        "guid": "bank",
+        "type": "bank",
+        "description": "Will accept direct bank transfers. Please e-mail me for details."
+      },
+      {
+        "guid": "opencollective",
+        "type": "other",
+        "description": "We are in the process of setting up an Open Collective. Please e-mail me for details."
+      }
+    ],
+    "plans": [
+      {
+        "guid": "bronze",
+        "status": "active",
+        "name": "Bronze sponsor",
+        "amount": 100,
+        "currency": "USD",
+        "frequency": "monthly",
+        "channels": [
+          "opencollective"
+        ]
+      }
+    ],
+    "history": []
+  }
+}


### PR DESCRIPTION
This PR creates a `funding.json` to be hosted at https://tus.io/funding.json. The idea is to use it to apply to the FLOSS/fund. Please see https://floss.fund/blog/announcing-floss-fund/ for more details on that. See https://floss.fund/funding-manifest/ for details on the manifest file.

The plans were inspired by unified's Open Collective page: https://opencollective.com/unified#category-CONTRIBUTE

Todos:
- [x] Revise plans
- [x] Link to Open Collective
- [ ] Ask Stefan if we should include tusdotnet
- [x] Create `funding-manifest-urls` in repositories
- [x] Check if the manifest validates at https://dir.floss.fund/validate
- [ ] Submit at https://dir.floss.fund/submit