### PR TITLE
Update implementation reference to tuspyserver

### DIFF
--- a/src/content/implementations/tuspyserver.json
+++ b/src/content/implementations/tuspyserver.json
@@ -1,12 +1,12 @@
 {
-  "href": "https://github.com/edihasaj/tuspy-fast-api",
+  "href": "https://github.com/edihasaj/tuspyserver",
   "authors": [
     {
       "name": "Edi Hasaj",
       "href": "https://github.com/edihasaj"
     }
   ],
-  "name": "edihasaj/tuspy-fast-api",
+  "name": "edihasaj/tuspyserver",
   "description": "<strong>FastAPI</strong> extension implementing tus <code>v1.0.0</code> powering resumable file uploads for <strong>Python</strong> servers and apps.",
   "license": "MIT",
   "type": "community",


### PR DESCRIPTION
Renamed references from "tuspy-fast-api" to "tuspyserver" in the JSON file to reflect the updated project name and repository link. This ensures consistency with the current naming and repository structure.

Changes come from the contribution: #https://github.com/edihasaj/tuspyserver/pull/58

