### PR TITLE
Harden dependency installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 18.x
       - run: corepack enable
       - run: corepack prepare
-      - run: yarn install
+      - run: yarn install --immutable
       # make sure types are generated before linting
       - run: yarn astro sync
       - run: yarn lint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: corepack enable
       - run: corepack prepare
-      - run: yarn install
+      - run: yarn install --immutable
       - run: yarn build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,5 @@ compressionLevel: mixed
 enableGlobalCache: false
 
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 2880

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tus-io",
   "version": "1.0.0",
   "main": "astro.config.mjs",
-  "packageManager": "yarn@4.3.1+sha512.af78262d7d125afbfeed740602ace8c5e4405cd7f4735c08feb327286b2fdb2390fbca01589bfd1f50b1240548b74806767f5a063c94b67e431aabd0d86f7774",
+  "packageManager": "yarn@4.12.0",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",


### PR DESCRIPTION
## Why
Recent npm supply-chain compromises showed that dependency installs and shared CI caches can execute or preserve newly published malicious packages before advisories catch up. This PR reduces that exposure for this repo.

## What changed
- Upgraded Yarn to 4.12.0, added the minimal age gate, and made CI/deploy installs immutable.

## Validation
- Ran `git diff --check` across the prepared worktree.
- Audited this PR set for `pull_request_target` and release/deploy/CDN cache reuse; patched actionable hits.
- Did not run the full test suite; this is a workflow/config-only change.