### PR TITLE
Refresh Yarn patch checksum

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12979,11 +12979,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=379a07"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/5d416ad4f2ea564f515a3f919e901edbfa4b497cc17dd325c5726046c3eef7ed22d1f59c787267d478311f6f0a265ff790f8a6c7e9df3ea3471458f5ec81e8b7
+  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Why

The main branch build started failing after enabling immutable Yarn installs because the lockfile still had the TypeScript compatibility patch checksum generated by the previous Yarn version. Yarn 4.12.0 wants the patch hash/checksum refreshed, and immutable mode correctly refuses to mutate the lockfile in CI.

What changed

- Refresh the TypeScript patch resolution/checksum in yarn.lock.

Verification

- corepack yarn install --immutable
- corepack yarn lint
- GITHUB_TOKEN=$(gh auth token) corepack yarn build