### PR TITLE
feat: add tusdfiber - native Go Fiber tus server implementation

### DIFF
--- a/src/content/implementations/tusdfiber.json
+++ b/src/content/implementations/tusdfiber.json
@@ -1,0 +1,14 @@
+{
+  "href": "https://github.com/maulanashalihin/tusdfiber",
+  "authors": [
+    {
+      "name": "Maulana Shalihin",
+      "href": "https://github.com/maulanashalihin"
+    }
+  ],
+  "name": "tusdfiber",
+  "description": "Native Go Fiber implementation. Supports TUS v1, IETF Resumable Upload Draft (v2), Prometheus metrics, and all tusd storage backends (FileStore, S3, GCS, Azure) with hooks (file, HTTP, gRPC). No <code>adaptor.HTTPHandler</code> needed.",
+  "license": "MIT",
+  "type": "community",
+  "subtype": "server"
+}


### PR DESCRIPTION
## Summary

Adds [tusdfiber](https://github.com/maulanashalihin/tusdfiber) to the Community > Server implementations list at [tus.io/implementations](https://tus.io/implementations).

## Details

tusdfiber is a native **Go Fiber** implementation of the TUS resumable upload protocol — no `adaptor.HTTPHandler` needed. All handlers accept `func(c *fiber.Ctx) error` directly.

**Features:**
- TUS v1 (POST, HEAD, PATCH, GET, DELETE, OPTIONS)
- IETF Resumable Upload Draft (v2) — `Upload-Draft-Interop-Version` 3–6
- Streaming body via fasthttp (no full buffering)
- Compatible with all tusd storage backends (FileStore, S3, GCS, Azure)
- File, HTTP, and gRPC hooks via tusd hook system
- Prometheus metrics (native Fiber, no adaptor)
- CORS, locking, method override, concatenation, deferred length
- 53 unit tests + E2E tests